### PR TITLE
Fix path cleanup for passing to command

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -219,10 +219,7 @@ export function runLintPass(
     return disposable;
   }
   const eslint = eslintPath;
-  // remove file:/Volumes/Macintosh HD from uri
-  const cleanPath = path
-    ? "/" + decodeURI(path).split("/").slice(5).join("/")
-    : null;
+  const cleanPath = path ? path.replace('file://', '') : null;
 
   disposable.add(
     verifySupportingPlugin(eslint, syntax, cleanPath, (message) => {
@@ -261,8 +258,7 @@ export function runFixPass(
     return disposable;
   }
   const eslint = eslintPath;
-  // remove file:/Volumes/Macintosh HD from uri
-  const cleanPath = "/" + decodeURI(path).split("/").slice(5).join("/");
+  const cleanPath = path.replace('file://', '');
 
   disposable.add(
     verifySupportingPlugin(eslint, syntax, cleanPath, (message) => {

--- a/src/process.ts
+++ b/src/process.ts
@@ -219,7 +219,7 @@ export function runLintPass(
     return disposable;
   }
   const eslint = eslintPath;
-  const cleanPath = path ? path.replace('file://', '') : null;
+  const cleanPath = path?.replace("file://", "") ?? null;
 
   disposable.add(
     verifySupportingPlugin(eslint, syntax, cleanPath, (message) => {
@@ -258,7 +258,7 @@ export function runFixPass(
     return disposable;
   }
   const eslint = eslintPath;
-  const cleanPath = path.replace('file://', '');
+  const cleanPath = path.replace("file://", "");
 
   disposable.add(
     verifySupportingPlugin(eslint, syntax, cleanPath, (message) => {


### PR DESCRIPTION
Nova 9 seems to have changed the return of document.uri and broke linting processes.

TextDocument.uri returns a file path and requires only removing the schema.