### PR TITLE
use npm-root rather than deprecated npm bin

### DIFF
--- a/src/getEslintPath.ts
+++ b/src/getEslintPath.ts
@@ -1,7 +1,7 @@
-async function npmBin(): Promise<string> {
+async function npmRoot(): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const process = new Process("/usr/bin/env", {
-      args: ["npm", "bin"],
+      args: ["npm", "root"],
       cwd: nova.workspace.path || nova.extension.path,
       stdio: ["ignore", "pipe", "pipe"],
       env: {
@@ -12,12 +12,12 @@ async function npmBin(): Promise<string> {
     process.onStdout((o) => {
       result += o;
     });
-    process.onStderr((e) => console.warn("npm bin:", e.trimRight()));
+    process.onStderr((e) => console.warn("npm root:", e.trimRight()));
     process.onDidExit((status) => {
       if (status === 0) {
         resolve(result.trim());
       } else {
-        reject(new Error("failed to npm bin"));
+        reject(new Error("failed to npm root"));
       }
     });
     process.start();
@@ -42,8 +42,9 @@ export async function getEslintPath(): Promise<string | null> {
       return null;
     }
   } else {
-    const npmBinDir = await npmBin();
-    execPath = nova.path.join(npmBinDir, "eslint");
+    const npmRootDir = await npmRoot();
+    execPath = nova.path.join(npmRootDir, ".bin/eslint");
+    console.log(execPath);
   }
 
   if (!nova.fs.access(execPath, nova.fs.X_OK)) {

--- a/src/getEslintPath.ts
+++ b/src/getEslintPath.ts
@@ -43,7 +43,7 @@ export async function getEslintPath(): Promise<string | null> {
     }
   } else {
     const npmRootDir = await npmRoot();
-    execPath = nova.path.join(npmRootDir, ".bin/eslint");
+    execPath = nova.path.join(npmRootDir, ".bin", "eslint");
   }
 
   if (!nova.fs.access(execPath, nova.fs.X_OK)) {

--- a/src/getEslintPath.ts
+++ b/src/getEslintPath.ts
@@ -44,7 +44,6 @@ export async function getEslintPath(): Promise<string | null> {
   } else {
     const npmRootDir = await npmRoot();
     execPath = nova.path.join(npmRootDir, ".bin/eslint");
-    console.log(execPath);
   }
 
   if (!nova.fs.access(execPath, nova.fs.X_OK)) {


### PR DESCRIPTION
[npm-bin](https://docs.npmjs.com/cli/v7/commands/npm-bin) has been deprecated and no longer available in npm v9 (which is now the default version in lts node).

[npm-root](https://docs.npmjs.com/cli/v7/commands/npm-root) is still supported by versions 6-9 of npm. 

Even though I believe https://github.com/apexskier/nova-eslint/pull/359 is a good change, it doesn't really fix the issue with npm bin, which will still get called if you don't specify an executable location. This PR removes npm-bin entirely in favor of npm-root, ONLY if the user does not have a specified executable location.